### PR TITLE
ConfigValidationSpec overwrite the database password unexpectedly.

### DIFF
--- a/src/test/scala/com/twitter/rowz/ConfigValidationSpec.scala
+++ b/src/test/scala/com/twitter/rowz/ConfigValidationSpec.scala
@@ -7,20 +7,6 @@ import java.io.File
 import config.{Rowz => RowzConfig}
 
 object ConfigValidationSpec extends Specification {
-  def setEnvVarForTest(key: String, value: String) {
-    val env      = System.getenv()
-    val mapClass = classOf[java.util.Collections].getDeclaredClasses() filter {
-      _.getName == "java.util.Collections$UnmodifiableMap"
-    } head
-
-    val field = mapClass.getDeclaredField("m")
-    field.setAccessible(true)
-
-    field.get(env).asInstanceOf[java.util.Map[String,String]].put(key, value)
-  }
-
-  setEnvVarForTest("DB_USERNAME", "root")
-  setEnvVarForTest("DB_PASSWORD", "pass")
 
   "Configuration Validation" should {
     "test.scala" in {


### PR DESCRIPTION
Hi all,

I tried to build Rowz but the build often failed at random. 
It seems ConfigValidationSpec overwrite the database password in the test. So I deleted it to fix. It works.

build command:
 env DB_USERNAME=xxxx DB_PASSWORD=xxx sbt clean package-dist

Error message:
 java.sql.SQLException: Access denied for user 'root'@'localhost' (using password: YES) (FutureTask.java:232)

The running test is in random order. So I think if ConfigValidationSpec run at first in test, all following tests throw SQLException.
If ConfigValidationSpec run at last in the test, all tests are success.

Let me know if this writing is not helpful.
Sorry for my poor English. Thanks.
